### PR TITLE
Fix no use link and add volume for /date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,7 @@ RUN mv /opt/downloads/serf /usr/bin
 ADD serf-start.sh /opt/sei-bin/
 ADD serf-join.sh /opt/sei-bin/
 
+VOLUME ["/data/hbase"]
+
 CMD ["/usr/bin/supervisord"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /opt/sei-bin/
 RUN mkdir -p /data/hbase
 RUN mkdir -p /root/.profile.d
 WORKDIR /opt
-ADD http://apache.org/dist/hbase/hbase-0.94.22/hbase-0.94.22.tar.gz /opt/downloads/
+ADD http://apache.org/dist/hbase/hbase-0.94.27/hbase-0.94.27.tar.gz /opt/downloads/
 RUN tar xzvf /opt/downloads/hbase-*gz && rm /opt/downloads/hbase-*gz
 RUN ["/bin/bash","-c","mv hbase-* /opt/hbase"]
 ADD start_hbase.sh /opt/sei-bin/

--- a/hbase-site.xml
+++ b/hbase-site.xml
@@ -3,7 +3,7 @@
 
   <property>
     <name>hbase.rootdir</name>
-    <value>file:////data/hbase/hbase\-${user.name}/hbase</value>
+    <value>file:////data/hbase/hbase${user.name}/hbase</value>
   </property>
   <property>
     <name>hbase.zookeeper.dns.interface</name>


### PR DESCRIPTION
I find this url is out of date "http://apache.org/dist/hbase/hbase-0.94.22/hbase-0.94.22.tar.gz"
we should change it to "http://apache.org/dist/hbase/hbase-0.94.27/hbase-0.94.27.tar.gz"

and add volume for /date/hbase