### PR TITLE
Uses var for hbase download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --update add rsyslog bash openjdk7 make wget
 RUN apk --update add --virtual builddeps build-base autoconf automake git python
 
 ENV TSDB_VERSION 2.2.0
-ENV HBASE_VERSION 1.1.3
+ENV HBASE_VERSION 1.1.4
 ENV JAVA_HOME /usr/lib/jvm/java-1.7-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.7-openjdk/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p /data/hbase
 RUN mkdir -p /root/.profile.d
 RUN mkdir -p /opt/downloads
 WORKDIR /opt/downloads
-RUN wget -O hbase-${HBASE_VERSION}.bin.tar.gz http://www-us.apache.org/dist/hbase/1.1.3/hbase-1.1.3-bin.tar.gz && \
+RUN wget -O hbase-${HBASE_VERSION}.bin.tar.gz http://www-us.apache.org/dist/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz && \
     tar xzvf hbase-${HBASE_VERSION}.bin.tar.gz && \
     mv hbase-${HBASE_VERSION} /opt/hbase && \
     rm hbase-${HBASE_VERSION}.bin.tar.gz


### PR DESCRIPTION
Dear Peter,

your branch works like a charm. I just changed the `Dockerfile` to replace the hardcoded HBASE download URL to use the variable `HBASE_VERSION`.

Cheers from Cologne,
Lukas