### PR TITLE
Hbase version is hard coded

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apk --update add --virtual builddeps \
 RUN mkdir -p /data/hbase /root/.profile.d /opt/downloads
 
 WORKDIR /opt/downloads
-RUN wget -O hbase-${HBASE_VERSION}.bin.tar.gz http://archive.apache.org/dist/hbase/1.1.3/hbase-1.1.3-bin.tar.gz && \
+RUN wget -O hbase-${HBASE_VERSION}.bin.tar.gz http://archive.apache.org/dist/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz && \
     tar xzvf hbase-${HBASE_VERSION}.bin.tar.gz && \
     mv hbase-${HBASE_VERSION} /opt/hbase && \
     rm hbase-${HBASE_VERSION}.bin.tar.gz


### PR DESCRIPTION
If you want to change hbase version to somethong different from 1.1.3 it will crash. I suggest to use the env variable (since I can't predict the path to get the file, I can't be 100% confident about the result)
