### PR TITLE
added customizable opentsdb.conf 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,10 @@ ADD docker/start_opentsdb.sh /opt/bin/
 ADD docker/create_tsdb_tables.sh /opt/bin/
 ADD docker/start_hbase.sh /opt/bin/
 
+# add additional config
+RUN mkdir /opt/opentsdb/config
+ADD opentsdb.conf
+
 RUN for i in /opt/bin/start_hbase.sh /opt/bin/start_opentsdb.sh /opt/bin/create_tsdb_tables.sh; \
     do \
         sed -i "s#::JAVA_HOME::#$JAVA_HOME#g; s#::PATH::#$PATH#g; s#::TSDB_VERSION::#$TSDB_VERSION#g;" $i; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ ADD docker/start_hbase.sh /opt/bin/
 
 # add additional config
 RUN mkdir /opt/opentsdb/config
-ADD opentsdb.conf
+ADD opentsdb.conf /opt/opentsdb/config
 
 RUN for i in /opt/bin/start_hbase.sh /opt/bin/start_opentsdb.sh /opt/bin/create_tsdb_tables.sh; \
     do \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 opentsdb:
     hostname: opentsdb
-    image: petergrace/opentsdb-docker:latest
+    image: krasv/opentsdb-docker:latest
     ports:
     - 4242:4242
     - 60030:60030
+    volumes:
+      - ./opentsdb:/opt/opentsdb/config/opentsdb.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 opentsdb:
     hostname: opentsdb
-    image: krasv/opentsdb-docker:latest
+    image: krasv/opentsdb-docker:v1
     ports:
     - 4242:4242
     - 60030:60030
     volumes:
-      - ./opentsdb:/opt/opentsdb/config/opentsdb.conf:ro
+      - ./opentsdb.conf:/opt/opentsdb/config/opentsdb.conf:ro

--- a/docker/start_opentsdb.sh
+++ b/docker/start_opentsdb.sh
@@ -10,4 +10,4 @@ if [ ! -e /opt/opentsdb_tables_created.txt ]; then
 fi
 
 echo "starting opentsdb"
-/opt/opentsdb/opentsdb-${TSDB_VERSION}/build/tsdb tsd --port=4242 --staticroot=/opt/opentsdb/opentsdb-${TSDB_VERSION}/build/staticroot --cachedir=/tmp --auto-metric
+/opt/opentsdb/opentsdb-${TSDB_VERSION}/build/tsdb tsd --port=4242 --staticroot=/opt/opentsdb/opentsdb-${TSDB_VERSION}/build/staticroot --cachedir=/tmp --auto-metric --config=/opt/opentsdb/config/opentsdb.conf

--- a/opentsdb.conf
+++ b/opentsdb.conf
@@ -1,0 +1,5 @@
+## put your additional opentsb settings here
+
+#tsd.http.request.enable_chunked = true
+#tsd.http.request.max_chunk = 1048576
+#tsd.http.query.allow_delete=true


### PR DESCRIPTION
Hi Peter,

I'd like to allowed customing the opentsdb like enable ts deletion or similar.
So I've added a default opentsdb.conf and referred to it within the start_opentsdb.sh

sven