### PR TITLE
Fix issue #29

### DIFF
--- a/files/create_tsdb_tables.sh
+++ b/files/create_tsdb_tables.sh
@@ -6,4 +6,4 @@ export TSDB_VERSION="::TSDB_VERSION::"
 export JAVA_HOME="::JAVA_HOME::"
 
 /usr/local/share/opentsdb/tools/create_table.sh
-touch /opt/opentsdb_tables_created.txt
+touch /data/hbase/opentsdb_tables_created.txt

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -4,8 +4,9 @@
 cleanup()
 {
     echo "SIGTERM received, trying to gracefully shutdown."
-    killall tsdb
-    /opt/hbase/bin/hbase_stop.sh
+    echo "diediedie" | nc localhost 4242
+    sleep 2
+    /opt/hbase/bin/stop-hbase.sh
 }
 trap cleanup TERM
 
@@ -29,4 +30,9 @@ sleep ${WAITSECS}
 touch /data/hbase/hbase_started
 
 echo "Starting opentsdb.  It should be available on port 4242 momentarily."
-/opt/bin/start_opentsdb.sh
+/opt/bin/start_opentsdb.sh &
+
+while [ 1 ]
+do
+    sleep 1
+done

--- a/files/start_opentsdb.sh
+++ b/files/start_opentsdb.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 export TSDB_VERSION="::TSDB_VERSION::"
 
-if [ ! -e /opt/opentsdb_tables_created.txt ]; then
+echo "listing /data/hbase"
+ls -lhat /data/hbase
+
+if [ ! -e /data/hbase/opentsdb_tables_created.txt ]; then
 	echo "creating tsdb tables"
 	bash /opt/bin/create_tsdb_tables.sh
 	echo "created tsdb tables"


### PR DESCRIPTION
An attempt to fix issue #29. Changes the way opentsdb is started to allow SIGTERM trap, and shutdown OpenTSDB using diediedie, instead of killall opentsdb, which seems to be failing.